### PR TITLE
Use tempfile.mkstemp instead of tempfile.mktemp

### DIFF
--- a/git/index/base.py
+++ b/git/index/base.py
@@ -339,7 +339,7 @@ class IndexFile(LazyMixin, git_diff.Diffable, Serializable):
 
         # tmp file created in git home directory to be sure renaming
         # works - /tmp/ dirs could be on another device
-        tmp_index = tempfile.mktemp('', '', repo.git_dir)
+        tmp_index = tempfile.mkdtemp('', '', repo.git_dir)
         arg_list.append("--index-output=%s" % tmp_index)
         arg_list.extend(treeish)
 

--- a/git/index/util.py
+++ b/git/index/util.py
@@ -38,7 +38,7 @@ class TemporaryFileSwap(object):
 
     def __init__(self, file_path: PathLike) -> None:
         self.file_path = file_path
-        self.tmp_file_path = str(self.file_path) + tempfile.mktemp('', '', '')
+        self.tmp_file_path = str(self.file_path) + tempfile.mkdtemp('', '', '')
         # it may be that the source does not exist
         try:
             os.rename(self.file_path, self.tmp_file_path)


### PR DESCRIPTION
The `tempfile.mktemp` function is [deprecated](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp) due to security issues.